### PR TITLE
EdnError rework with `parse` rewrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ unsafe_code = "deny"
 [lints.clippy]
 pedantic = "warn"
 nursery = "warn"
+inline_always = "allow"
 
 [features]
 default = ["sets", "std"]

--- a/examples/complex_struct_deserialization.rs
+++ b/examples/complex_struct_deserialization.rs
@@ -70,12 +70,7 @@ fn complex_wrong() -> Result<(), EdnError> {
     let bad_edn_str = "{:list [{:name \"rose\" :age \"some text\" :cool true}, {:name \"josh\" :age 33 :cool false}, {:name \"eva\" :age 296 :cool true}]}";
     let complex: Result<Complex, EdnError> = edn_rs::from_str(bad_edn_str);
 
-    assert_eq!(
-        complex,
-        Err(EdnError::Deserialize(
-            "couldn't convert `\"some text\"` into `uint`".to_string()
-        ))
-    );
+    assert!(complex.is_err());
 
     Ok(())
 }

--- a/examples/from_edn.rs
+++ b/examples/from_edn.rs
@@ -42,12 +42,7 @@ fn person_mistyped() -> Result<(), EdnError> {
     }));
     let person: Result<Person, EdnError> = edn_rs::from_edn(&bad_edn);
 
-    assert_eq!(
-        person,
-        Err(EdnError::Deserialize(
-            "couldn't convert `\"some text\"` into `uint`".to_string()
-        ))
-    );
+    assert!(person.is_err());
 
     Ok(())
 }

--- a/examples/struct_from_str.rs
+++ b/examples/struct_from_str.rs
@@ -36,13 +36,7 @@ fn person_mistyped() -> Result<(), EdnError> {
     let bad_edn_str = "{:name \"rose\" :age \"some text\" }";
     let person: Result<Person, EdnError> = edn_rs::from_str(bad_edn_str);
 
-    assert_eq!(
-        person,
-        Err(EdnError::Deserialize(
-            "couldn't convert `\"some text\"` into `uint`".to_string()
-        ))
-    );
-
+    assert!(person.is_err());
     Ok(())
 }
 
@@ -50,11 +44,7 @@ fn person_overflow() -> Result<(), EdnError> {
     let overflow_edn_str = "  {:name \"rose\" :age 9002  }  ";
     let person: Result<Person, EdnError> = edn_rs::from_str(overflow_edn_str);
 
-    assert_eq!(
-        format!("{person:?}"),
-        "Err(TryFromInt(TryFromIntError(())))"
-    );
-
+    assert!(person.is_err());
     Ok(())
 }
 

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -23,7 +23,7 @@ use ordered_float::OrderedFloat;
 ///
 /// # Errors
 ///
-/// Error implements Display and Debug. See docs for more implementations.
+/// Error implements Debug. See docs for more information.
 ///
 /// ```
 /// use crate::edn_rs::{Edn, EdnError, Deserialize};

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -60,12 +60,7 @@ use ordered_float::OrderedFloat;
 /// let bad_edn_str = "{:name \"rose\" :age \"some text\" }";
 /// let person: Result<Person, EdnError> = edn_rs::from_str(bad_edn_str);
 ///
-/// assert_eq!(
-///     person,
-///     Err(EdnError::Deserialize(
-///         "couldn't convert `\"some text\"` into `uint`".to_string()
-///     ))
-/// );
+/// println!("{:?}", person);
 /// ```
 #[allow(clippy::missing_errors_doc)]
 pub trait Deserialize: Sized {
@@ -348,12 +343,7 @@ where
 /// let bad_edn_str = "{:name \"rose\" :age \"some text\" }";
 /// let person: Result<Person, EdnError> = edn_rs::from_str(bad_edn_str);
 ///
-/// assert_eq!(
-///     person,
-///     Err(EdnError::Deserialize(
-///             "couldn't convert `\"some text\"` into `uint`".to_string()
-///     ))
-/// );
+/// println!("{:?}", person);
 /// ```
 pub fn from_str<T: Deserialize>(s: &str) -> Result<T, Error> {
     let edn = Edn::from_str(s)?;
@@ -407,12 +397,7 @@ pub fn from_str<T: Deserialize>(s: &str) -> Result<T, Error> {
 /// }));
 /// let person: Result<Person, EdnError> = edn_rs::from_edn(&bad_edn);
 ///
-/// assert_eq!(
-///     person,
-///     Err(EdnError::Deserialize(
-///         "couldn't convert `\"some text\"` into `uint`".to_string()
-///     ))
-/// );
+/// println!("{:?}", person);
 /// ```
 pub fn from_edn<T: Deserialize>(edn: &Edn) -> Result<T, Error> {
     T::deserialize(edn)

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -1,7 +1,6 @@
 use alloc::collections::BTreeMap;
 #[cfg(feature = "sets")]
 use alloc::collections::BTreeSet;
-use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::any;
@@ -12,7 +11,8 @@ use std::collections::HashMap;
 #[cfg(all(feature = "sets", feature = "std"))]
 use std::collections::HashSet;
 
-use crate::edn::{Edn, Error};
+use crate::edn::Edn;
+use crate::EdnError as Error;
 
 pub mod parse;
 
@@ -23,7 +23,7 @@ use ordered_float::OrderedFloat;
 ///
 /// # Errors
 ///
-/// Error will be like `EdnError::Deserialize("couldn't convert <value> into <type>")`
+/// Error implements Display and Debug. See docs for more implementations.
 ///
 /// ```
 /// use crate::edn_rs::{Edn, EdnError, Deserialize};
@@ -67,15 +67,15 @@ pub trait Deserialize: Sized {
     fn deserialize(edn: &Edn) -> Result<Self, Error>;
 }
 
-fn build_deserialize_error(edn: &Edn, type_: &str) -> Error {
-    Error::Deserialize(format!("couldn't convert `{edn}` into `{type_}`"))
+const fn build_deserialize_error(type_: &'static str) -> Error {
+    Error::deserialize(type_)
 }
 
 impl Deserialize for () {
     fn deserialize(edn: &Edn) -> Result<Self, Error> {
         match edn {
             Edn::Nil => Ok(()),
-            _ => Err(build_deserialize_error(edn, "unit")),
+            _ => Err(build_deserialize_error("unit")),
         }
     }
 }
@@ -84,7 +84,7 @@ impl Deserialize for () {
 impl Deserialize for OrderedFloat<f64> {
     fn deserialize(edn: &Edn) -> Result<Self, Error> {
         edn.to_float()
-            .ok_or_else(|| build_deserialize_error(edn, "edn_rs::Double"))
+            .ok_or_else(|| build_deserialize_error("edn_rs::Double"))
             .map(Into::into)
     }
 }
@@ -92,7 +92,7 @@ impl Deserialize for OrderedFloat<f64> {
 impl Deserialize for f64 {
     fn deserialize(edn: &Edn) -> Result<Self, Error> {
         edn.to_float()
-            .ok_or_else(|| build_deserialize_error(edn, "edn_rs::Double"))
+            .ok_or_else(|| build_deserialize_error("edn_rs::Double"))
             .map(Into::into)
     }
 }
@@ -104,7 +104,7 @@ macro_rules! impl_deserialize_int {
                 fn deserialize(edn: &Edn) -> Result<Self, Error> {
                     let int = edn
                         .to_int()
-                        .ok_or_else(|| build_deserialize_error(edn, "int"))?;
+                        .ok_or_else(|| build_deserialize_error("int"))?;
                     Ok(Self::try_from(int)?)
                 }
             }
@@ -121,7 +121,7 @@ macro_rules! impl_deserialize_uint {
                 fn deserialize(edn: &Edn) -> Result<Self, Error> {
                     let uint = edn
                         .to_uint()
-                        .ok_or_else(|| build_deserialize_error(edn, "uint"))?;
+                        .ok_or_else(|| build_deserialize_error("uint"))?;
                     Ok(Self::try_from(uint)?)
                 }
             }
@@ -133,8 +133,7 @@ impl_deserialize_uint!(u8, u16, u32, u64, usize);
 
 impl Deserialize for bool {
     fn deserialize(edn: &Edn) -> Result<Self, Error> {
-        edn.to_bool()
-            .ok_or_else(|| build_deserialize_error(edn, "bool"))
+        edn.to_bool().ok_or_else(|| build_deserialize_error("bool"))
     }
 }
 
@@ -155,8 +154,7 @@ impl Deserialize for String {
 
 impl Deserialize for char {
     fn deserialize(edn: &Edn) -> Result<Self, Error> {
-        edn.to_char()
-            .ok_or_else(|| build_deserialize_error(edn, "char"))
+        edn.to_char().ok_or_else(|| build_deserialize_error("char"))
     }
 }
 
@@ -168,21 +166,21 @@ where
         match edn {
             Edn::Vector(_) => Ok(edn
                 .iter_some()
-                .ok_or_else(|| Error::Iter(format!("Could not create iter from {edn:?}")))?
+                .ok_or_else(Error::iter)?
                 .map(|e| Deserialize::deserialize(e))
                 .collect::<Result<Self, Error>>()?),
             Edn::List(_) => Ok(edn
                 .iter_some()
-                .ok_or_else(|| Error::Iter(format!("Could not create iter from {edn:?}")))?
+                .ok_or_else(Error::iter)?
                 .map(|e| Deserialize::deserialize(e))
                 .collect::<Result<Self, Error>>()?),
             #[cfg(feature = "sets")]
             Edn::Set(_) => Ok(edn
                 .iter_some()
-                .ok_or_else(|| Error::Iter(format!("Could not create iter from {edn:?}")))?
+                .ok_or_else(Error::iter)?
                 .map(|e| Deserialize::deserialize(e))
                 .collect::<Result<Self, Error>>()?),
-            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(any::type_name::<Self>())),
         }
     }
 }
@@ -197,20 +195,15 @@ where
         match edn {
             Edn::Map(_) => edn
                 .map_iter()
-                .ok_or_else(|| Error::Iter(format!("Could not create iter from {edn:?}")))?
+                .ok_or_else(Error::iter)?
                 .map(|(key, e)| {
                     Ok((
                         key.to_string(),
-                        Deserialize::deserialize(e).map_err(|_| {
-                            Error::Deserialize(format!(
-                                "Cannot safely deserialize {:?} to {}",
-                                edn, "HashMap"
-                            ))
-                        })?,
+                        Deserialize::deserialize(e).map_err(|_| Error::deserialize("HashMap"))?,
                     ))
                 })
                 .collect::<Result<Self, Error>>(),
-            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(any::type_name::<Self>())),
         }
     }
 }
@@ -223,20 +216,15 @@ where
         match edn {
             Edn::Map(_) => edn
                 .map_iter()
-                .ok_or_else(|| Error::Iter(format!("Could not create iter from {edn:?}")))?
+                .ok_or_else(Error::iter)?
                 .map(|(key, e)| {
                     Ok((
                         key.to_string(),
-                        Deserialize::deserialize(e).map_err(|_| {
-                            Error::Deserialize(format!(
-                                "Cannot safely deserialize {:?} to {}",
-                                edn, "BTreeMap"
-                            ))
-                        })?,
+                        Deserialize::deserialize(e).map_err(|_| Error::deserialize("BTreeMap"))?,
                     ))
                 })
                 .collect::<Result<Self, Error>>(),
-            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(any::type_name::<Self>())),
         }
     }
 }
@@ -251,17 +239,10 @@ where
         match edn {
             Edn::Set(_) => edn
                 .set_iter()
-                .ok_or_else(|| Error::Iter(format!("Could not create iter from {edn:?}")))?
-                .map(|e| {
-                    Deserialize::deserialize(e).map_err(|_| {
-                        Error::Deserialize(format!(
-                            "Cannot safely deserialize {:?} to {}",
-                            edn, "HashSet"
-                        ))
-                    })
-                })
+                .ok_or_else(Error::iter)?
+                .map(|e| Deserialize::deserialize(e).map_err(|_| Error::deserialize("HashSet")))
                 .collect::<Result<Self, Error>>(),
-            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(any::type_name::<Self>())),
         }
     }
 }
@@ -275,17 +256,10 @@ where
         match edn {
             Edn::Set(_) => edn
                 .set_iter()
-                .ok_or_else(|| Error::Iter(format!("Could not create iter from {edn:?}")))?
-                .map(|e| {
-                    Deserialize::deserialize(e).map_err(|_| {
-                        Error::Deserialize(format!(
-                            "Cannot safely deserialize {:?} to {}",
-                            edn, "BTreeSet"
-                        ))
-                    })
-                })
+                .ok_or_else(Error::iter)?
+                .map(|e| Deserialize::deserialize(e).map_err(|_| Error::deserialize("BTreeSet")))
                 .collect::<Result<Self, Error>>(),
-            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(any::type_name::<Self>())),
         }
     }
 }

--- a/src/deserialize/parse.rs
+++ b/src/deserialize/parse.rs
@@ -1,189 +1,505 @@
+use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 #[cfg(feature = "sets")]
 use alloc::collections::BTreeSet;
+use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use alloc::{format, vec};
-use core::iter;
 use core::primitive::str;
 
+use crate::edn::error::{Code, Error};
 #[cfg(feature = "sets")]
 use crate::edn::Set;
-use crate::edn::{Edn, Error, List, Map, Vector};
+use crate::edn::{Edn, List, Map, Vector};
 
 const DELIMITERS: [char; 8] = [',', ']', '}', ')', ';', '(', '[', '{'];
 
-pub fn parse(edn: &str) -> Result<Edn, Error> {
-    let owned = String::from(edn);
-    let mut tokens = owned.chars().enumerate();
-    (parse_internal(tokens.next(), &mut tokens)?).map_or_else(|| Ok(Edn::Empty), Ok)
+#[derive(Debug)]
+struct Walker<'w> {
+    slice: &'w str,
+    ptr: usize,
+    column: usize,
+    line: usize,
 }
 
-fn parse_consuming(
-    c: Option<(usize, char)>,
-    chars: &mut iter::Enumerate<core::str::Chars<'_>>,
-) -> Result<Edn, Error> {
-    (parse_internal(c, chars)?).map_or_else(|| Ok(Edn::Empty), Ok)
-}
+impl Walker<'_> {
+    // Slurps until whitespace or delimiter, returning the slice.
+    #[inline]
+    fn slurp_literal(&mut self) -> &str {
+        let token = self.slice[self.ptr..]
+            .split(|c: char| c.is_whitespace() || DELIMITERS.contains(&c))
+            .next()
+            .unwrap(); // At least an empty slice will always be on the first split, even on an empty str
 
-fn parse_internal(
-    c: Option<(usize, char)>,
-    chars: &mut iter::Enumerate<core::str::Chars<'_>>,
-) -> Result<Option<Edn>, Error> {
-    Ok(match c {
-        Some((_, '[')) => Some(read_vec(chars)?),
-        Some((_, '(')) => Some(read_list(chars)?),
-        Some((_, '#')) => tagged_or_set_or_discard(chars)?,
-        Some((_, '{')) => Some(read_map(chars)?),
-        Some((_, ';')) => {
-            // Consumes the content
-            chars.find(|c| c.1 == '\n');
-            read_if_not_container_end(chars)?
+        self.ptr += token.len();
+        self.column += token.len();
+        token
+    }
+
+    // Slurps a char. Special handling for chars that happen to be delimiters
+    #[inline]
+    fn slurp_char(&mut self) -> &str {
+        let starting_ptr = self.ptr;
+
+        let mut ptr = 0;
+        while let Some(c) = self.peek_next() {
+            // first is always \\, second is always a char we want.
+            // Handles edge cases of having a valid "\\[" but also "\\c[lolthisisvalidedn"
+            if ptr > 1 && (c.is_whitespace() || DELIMITERS.contains(&c)) {
+                break;
+            }
+
+            let _ = self.nibble_next();
+            ptr += 1;
         }
-        Some((_, s)) if s.is_whitespace() || s == ',' => read_if_not_container_end(chars)?,
-        None => None,
-        edn => Some(edn_element(edn, chars)?),
+        &self.slice[starting_ptr..starting_ptr + ptr]
+    }
+
+    // Slurps until whitespace or delimiter, returning the slice.
+    #[inline]
+    fn slurp_tag(&mut self) -> &str {
+        let token = self.slice[self.ptr..]
+            .split(|c: char| c.is_whitespace() && c != ',')
+            .next()
+            .unwrap(); // At least an empty slice will always be on the first split, even on an empty str
+
+        self.ptr += token.len();
+        self.column += token.len();
+
+        if token.ends_with(',') {
+            return &token[0..token.len() - 1];
+        }
+        token
+    }
+
+    #[inline]
+    fn slurp_str(&mut self) -> Result<Edn, Error> {
+        let _ = self.nibble_next(); // Consume the leading '"' char
+        let mut s = String::new();
+        let mut escape = false;
+        loop {
+            if let Some(c) = self.nibble_next() {
+                if escape {
+                    match c {
+                        't' => s.push('\t'),
+                        'r' => s.push('\r'),
+                        'n' => s.push('\n'),
+                        '\\' => s.push('\\'),
+                        '\"' => s.push('\"'),
+                        _ => {
+                            return Err(Error {
+                                code: Code::InvalidEscape,
+                                column: Some(self.column),
+                                line: Some(self.line),
+                            })
+                        }
+                    }
+                    escape = false;
+                } else if c == '\"' {
+                    return Ok(Edn::Str(s));
+                } else if c == '\\' {
+                    escape = true;
+                } else {
+                    escape = false;
+                    s.push(c);
+                }
+            } else {
+                return Err(Error {
+                    code: Code::UnexpectedEOF,
+                    column: Some(self.column),
+                    line: Some(self.line),
+                });
+            }
+        }
+    }
+
+    // Nibbles away until the next new line
+    #[inline]
+    fn nibble_newline(&mut self) {
+        let len = self.slice[self.ptr..].split('\n').next().unwrap(); // At least an empty slice will always be on the first split, even on an empty str
+        self.line += 1;
+        self.column = 1;
+        self.ptr += len.len();
+        self.nibble_whitespace();
+    }
+
+    // Nibbles away until the start of the next form
+    #[inline]
+    fn nibble_whitespace(&mut self) {
+        while let Some(n) = self.peek_next() {
+            if n == ',' || n.is_whitespace() {
+                let _ = self.nibble_next();
+                continue;
+            }
+            break;
+        }
+    }
+
+    // Consumes next
+    #[inline]
+    fn nibble_next(&mut self) -> Option<char> {
+        let char = self.slice[self.ptr..].chars().next();
+        if let Some(c) = char {
+            self.ptr += 1;
+            if c == '\n' {
+                self.line += 1;
+                self.column = 1;
+            } else {
+                self.column += 1;
+            }
+        }
+        char
+    }
+
+    // Peek into the next char
+    #[inline]
+    fn peek_next(&mut self) -> Option<char> {
+        self.slice[self.ptr..].chars().next()
+    }
+}
+
+pub fn parse(edn: &str) -> Result<Edn, Error> {
+    let mut walker = Walker {
+        slice: edn,
+        ptr: 0,
+        column: 1,
+        line: 1,
+    };
+
+    parse_foobar(&mut walker)
+}
+
+fn parse_foobar(walker: &mut Walker<'_>) -> Result<Edn, Error> {
+    walker.nibble_whitespace();
+    while let Some(next) = walker.peek_next() {
+        let column_start = walker.column;
+        if let Some(ret) = match next {
+            '\\' => match parse_char(walker.slurp_char()) {
+                Ok(edn) => Some(Ok(edn)),
+                Err(code) => {
+                    return Err(Error {
+                        code,
+                        line: Some(walker.line),
+                        column: Some(column_start),
+                    })
+                }
+            },
+            '\"' => Some(walker.slurp_str()),
+            // comment. consume until a new line.
+            ';' => {
+                walker.nibble_newline();
+                None
+            }
+            '[' => return parse_vector(walker),
+            '(' => return parse_list(walker),
+            '{' => return parse_map(walker),
+            '#' => parse_tag_set_discard(walker)?.map(Ok),
+            // non-string literal case
+            _ => match edn_literal(walker.slurp_literal()) {
+                Ok(edn) => Some(Ok(edn)),
+                Err(code) => {
+                    return Err(Error {
+                        code,
+                        line: Some(walker.line),
+                        column: Some(column_start),
+                    })
+                }
+            },
+        } {
+            return ret;
+        }
+    }
+    Ok(Edn::Empty)
+}
+
+fn parse_tag_set_discard(walker: &mut Walker<'_>) -> Result<Option<Edn>, Error> {
+    let _ = walker.nibble_next(); // Consume the leading '#' char
+
+    match walker.peek_next() {
+        Some('{') => parse_set(walker).map(Some),
+        Some('_') => parse_discard(walker),
+        _ => parse_tag(walker).map(Some),
+    }
+}
+
+fn parse_discard(walker: &mut Walker<'_>) -> Result<Option<Edn>, Error> {
+    let _ = walker.nibble_next(); // Consume the leading '_' char
+    Ok(match parse_foobar(walker)? {
+        Edn::Empty => {
+            return Err(Error {
+                code: Code::UnexpectedEOF,
+                line: Some(walker.line),
+                column: Some(walker.column),
+            })
+        }
+        _ => match walker.peek_next() {
+            Some(_) => Some(parse_foobar(walker)?),
+            None => None,
+        },
     })
 }
 
-fn edn_element(
-    c: Option<(usize, char)>,
-    chars: &mut iter::Enumerate<core::str::Chars<'_>>,
-) -> Result<Edn, Error> {
-    match c {
-        Some((_, '\"')) => read_str(chars),
-        Some((_, ':')) => Ok(read_key(chars)),
-        Some((_, n)) if n.is_numeric() => Ok(read_number(n, chars)?),
-        Some((_, n))
-            if (n == '-' || n == '+')
-                && chars
-                    .clone()
-                    .peekable()
-                    .peek()
-                    .is_some_and(|n| n.1.is_numeric()) =>
-        {
-            Ok(read_number(n, chars)?)
-        }
-        Some((_, '\\')) => Ok(read_char(chars)?),
-        Some((_, b)) if b == 't' || b == 'f' || b == 'n' => Ok(read_bool_or_nil(b, chars)?),
-        Some((_, a)) => Ok(read_symbol(a, chars)?),
-        None => Err(Error::ParseEdn("Edn could not be parsed".to_string())),
-    }
-}
+#[cfg(feature = "sets")]
+fn parse_set(walker: &mut Walker<'_>) -> Result<Edn, Error> {
+    let _ = walker.nibble_next(); // Consume the leading '{' char
+    let mut set: BTreeSet<Edn> = BTreeSet::new();
 
-fn tagged_or_set_or_discard(
-    chars: &mut iter::Enumerate<core::str::Chars<'_>>,
-) -> Result<Option<Edn>, Error> {
-    match chars.clone().next() {
-        Some((_, '{')) => read_set(chars).map(Some),
-        Some((_, '_')) => read_discard(chars),
-        _ => read_tagged(chars).map(Some),
-    }
-}
-
-fn read_key(chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Edn {
-    let key_chars = chars
-        .clone()
-        .take_while(|c| !c.1.is_whitespace() && !DELIMITERS.contains(&c.1));
-    let c_len = key_chars.clone().count();
-
-    let mut key = String::from(":");
-    let key_chars = chars.take(c_len).map(|c| c.1).collect::<String>();
-    key.push_str(&key_chars);
-    Edn::Key(key)
-}
-
-fn read_str(chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Result<Edn, Error> {
-    let result = chars.try_fold(
-        (false, String::new()),
-        |(last_was_escape, mut s), (_, c)| {
-            if last_was_escape {
-                // Supported escape characters, per https://github.com/edn-format/edn#strings
-                match c {
-                    't' => s.push('\t'),
-                    'r' => s.push('\r'),
-                    'n' => s.push('\n'),
-                    '\\' => s.push('\\'),
-                    '\"' => s.push('\"'),
-                    _ => {
-                        return Err(Err(Error::ParseEdn(format!(
-                            "Invalid escape sequence \\{c}"
-                        ))))
-                    }
-                };
-
-                Ok((false, s))
-            } else if c == '\"' {
-                // Unescaped quote means we're done
-                Err(Ok(s))
-            } else if c == '\\' {
-                Ok((true, s))
-            } else {
-                s.push(c);
-                Ok((false, s))
+    loop {
+        match walker.peek_next() {
+            Some('}') => {
+                let _ = walker.nibble_next();
+                return Ok(Edn::Set(Set::new(set)));
             }
-        },
-    );
-
-    match result {
-        // An Ok means we actually finished parsing *without* seeing the end of the string, so that's
-        // an error.
-        Ok(_) => Err(Error::ParseEdn("Unterminated string".to_string())),
-        Err(Err(e)) => Err(e),
-        Err(Ok(string)) => Ok(Edn::Str(string)),
+            Some(_) => {
+                let next = parse_foobar(walker)?;
+                if next != Edn::Empty {
+                    set.insert(next);
+                }
+            }
+            _ => {
+                return Err(Error {
+                    code: Code::UnexpectedEOF,
+                    line: Some(walker.line),
+                    column: Some(walker.column),
+                })
+            }
+        }
     }
 }
 
-fn read_symbol(a: char, chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Result<Edn, Error> {
-    let c_len = chars
-        .clone()
-        .enumerate()
-        .take_while(|&(_, c)| !c.1.is_whitespace() && !DELIMITERS.contains(&c.1))
-        .count();
-    let i = chars
-        .clone()
-        .next()
-        .ok_or_else(|| Error::ParseEdn("Could not identify symbol index".to_string()))?
-        .0;
-
-    if a.is_whitespace() {
-        return Err(Error::ParseEdn(format!(
-            "\"{a}\" could not be parsed at char count {i}"
-        )));
-    }
-
-    let mut symbol = String::from(a);
-    let symbol_chars = chars.take(c_len).map(|c| c.1).collect::<String>();
-    symbol.push_str(&symbol_chars);
-    Ok(Edn::Symbol(symbol))
+#[cfg(not(feature = "sets"))]
+const fn parse_set(walker: &Walker<'_>) -> Result<Edn, Error> {
+    Err(Error {
+        code: Code::NoFeatureSets,
+        line: Some(walker.line),
+        column: Some(walker.column),
+    })
 }
 
-fn read_tagged(chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Result<Edn, Error> {
-    let tag = chars
-        .take_while(|c| !c.1.is_whitespace() && c.1 != ',')
-        .map(|c| c.1)
-        .collect::<String>();
-
+fn parse_tag(walker: &mut Walker<'_>) -> Result<Edn, Error> {
+    let tag = walker.slurp_tag();
     Ok(Edn::Tagged(
-        tag,
-        Box::new(parse_consuming(chars.next(), chars)?),
+        tag.to_string(),
+        Box::new(parse_foobar(walker)?),
     ))
 }
 
-fn read_discard(chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Result<Option<Edn>, Error> {
-    let _discard_underscore = chars.next();
-    let i = chars
-        .clone()
-        .next()
-        .ok_or_else(|| Error::ParseEdn("Could not identify symbol index".to_string()))?
-        .0;
-    match parse_consuming(chars.next(), chars) {
-        Err(e) => Err(e),
-        Ok(Edn::Empty) => Err(Error::ParseEdn(format!(
-            "Discard sequence must have a following element at char count {i}"
-        ))),
-        _ => read_if_not_container_end(chars),
+fn parse_map(walker: &mut Walker<'_>) -> Result<Edn, Error> {
+    let _ = walker.nibble_next(); // Consume the leading '{' char
+    let mut map: BTreeMap<String, Edn> = BTreeMap::new();
+    loop {
+        match walker.peek_next() {
+            Some('}') => {
+                let _ = walker.nibble_next();
+                return Ok(Edn::Map(Map::new(map)));
+            }
+            Some(n) => {
+                if n == ']' || n == ')' {
+                    return Err(Error {
+                        code: Code::UnmatchedDelimiter(n),
+                        line: Some(walker.line),
+                        column: Some(walker.column),
+                    });
+                }
+
+                let key = parse_foobar(walker)?;
+                let val = parse_foobar(walker)?;
+
+                if key != Edn::Empty && val != Edn::Empty {
+                    map.insert(key.to_string(), val);
+                }
+            }
+            _ => {
+                return Err(Error {
+                    code: Code::UnexpectedEOF,
+                    line: Some(walker.line),
+                    column: Some(walker.column),
+                })
+            }
+        }
+    }
+}
+
+fn parse_vector(walker: &mut Walker<'_>) -> Result<Edn, Error> {
+    let _ = walker.nibble_next(); // Consume the leading '[' char
+    let mut vec = Vec::new();
+
+    loop {
+        match walker.peek_next() {
+            Some(']') => {
+                let _ = walker.nibble_next();
+                return Ok(Edn::Vector(Vector::new(vec)));
+            }
+            Some(_) => {
+                let next = parse_foobar(walker)?;
+                if next != Edn::Empty {
+                    vec.push(next);
+                }
+            }
+            _ => {
+                return Err(Error {
+                    code: Code::UnexpectedEOF,
+                    line: Some(walker.line),
+                    column: Some(walker.column),
+                })
+            }
+        }
+    }
+}
+
+fn parse_list(walker: &mut Walker<'_>) -> Result<Edn, Error> {
+    let _ = walker.nibble_next(); // Consume the leading '[' char
+    let mut vec = Vec::new();
+
+    loop {
+        match walker.peek_next() {
+            Some(')') => {
+                let _ = walker.nibble_next();
+                return Ok(Edn::List(List::new(vec)));
+            }
+            Some(_) => {
+                let next = parse_foobar(walker)?;
+                if next != Edn::Empty {
+                    vec.push(next);
+                }
+            }
+            _ => {
+                return Err(Error {
+                    code: Code::UnexpectedEOF,
+                    line: Some(walker.line),
+                    column: Some(walker.column),
+                })
+            }
+        }
+    }
+}
+
+fn edn_literal(literal: &str) -> Result<Edn, Code> {
+    fn numeric(s: &str) -> bool {
+        let mut s = s.chars();
+        let first = s.next();
+        let second = s.next();
+
+        if let Some(f) = first {
+            if f.is_numeric() {
+                return true;
+            }
+
+            if f == '-' || f == '+' {
+                if let Some(s) = second {
+                    if s.is_numeric() {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    Ok(match literal {
+        "nil" => Edn::Nil,
+        "true" => Edn::Bool(true),
+        "false" => Edn::Bool(false),
+        "" => Edn::Empty,
+        k if k.starts_with(':') => {
+            if k.len() <= 1 {
+                return Err(Code::InvalidKeyword);
+            }
+            Edn::Key(k.to_owned())
+        }
+        n if numeric(n) => return parse_number(n),
+        _ => Edn::Symbol(literal.to_owned()),
+        // Some((_, '\\')) => Ok(read_char(chars)?),
+    })
+}
+
+fn parse_char(lit: &str) -> Result<Edn, Code> {
+    let lit = &lit[1..]; // ignore the leading '\\'
+    match lit {
+        "newline" => Ok(Edn::Char('\n')),
+        "return" => Ok(Edn::Char('\r')),
+        "tab" => Ok(Edn::Char('\t')),
+        "space" => Ok(Edn::Char(' ')),
+        c if c.len() == 1 => Ok(Edn::Char(c.chars().next().unwrap())),
+        _ => Err(Code::InvalidChar),
+    }
+}
+
+fn parse_number(lit: &str) -> Result<Edn, Code> {
+    let mut chars = lit.chars();
+    let (number, radix) = {
+        let mut number = String::new();
+
+        // The EDN spec allows for a redundant '+' symbol, we just ignore it.
+        if let Some(n) = chars.next() {
+            if n != '+' {
+                number.push(n);
+            }
+        }
+
+        for c in chars {
+            number.push(c);
+        }
+        if number.to_lowercase().starts_with("0x") {
+            number.remove(0);
+            number.remove(0);
+            (number, 16)
+        } else if number.to_lowercase().starts_with("-0x") {
+            number.remove(1);
+            number.remove(1);
+            (number, 16)
+        } else if let Some(index) = number.to_lowercase().find('r') {
+            let negative = number.starts_with('-');
+            let radix = {
+                if negative {
+                    (number[1..index]).parse::<u8>()
+                } else {
+                    (number[0..index]).parse::<u8>()
+                }
+            };
+            match radix {
+                Ok(r) => {
+                    // from_str_radix panics if radix is not in the range from 2 to 36
+                    if !(2..=36).contains(&r) {
+                        return Err(Code::InvalidRadix(Some(r)));
+                    }
+
+                    if negative {
+                        for _ in 0..(index) {
+                            number.remove(1);
+                        }
+                    } else {
+                        for _ in 0..=index {
+                            number.remove(0);
+                        }
+                    }
+                    (number, r)
+                }
+                Err(_) => {
+                    return Err(Code::InvalidRadix(None));
+                }
+            }
+        } else {
+            (number, 10)
+        }
+    };
+
+    match number {
+        n if (n.contains('E') || n.contains('e')) && n.parse::<f64>().is_ok() => {
+            Ok(Edn::Double(n.parse::<f64>()?.into()))
+        }
+        n if u64::from_str_radix(&n, radix.into()).is_ok() => {
+            Ok(Edn::UInt(u64::from_str_radix(&n, radix.into())?))
+        }
+        n if i64::from_str_radix(&n, radix.into()).is_ok() => {
+            Ok(Edn::Int(i64::from_str_radix(&n, radix.into())?))
+        }
+        n if n.parse::<f64>().is_ok() => Ok(Edn::Double(n.parse::<f64>()?.into())),
+        n if num_den_from_slice(&n).is_some() => Ok(Edn::Rational(num_den_from_slice(n).unwrap())),
+        _ => Err(Code::Message(
+            format!("{number} could not be parsed with radix {radix}").into_boxed_str(),
+        )),
     }
 }
 
@@ -203,317 +519,3 @@ fn num_den_from_slice(slice: impl AsRef<str>) -> Option<(i64, u64)> {
     }
     None
 }
-
-fn read_number(n: char, chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Result<Edn, Error> {
-    let c_len = chars
-        .clone()
-        .take_while(|(_, c)| !c.is_whitespace() && !DELIMITERS.contains(c))
-        .count();
-    let (number, radix) = {
-        let mut number = String::new();
-        // The EDN spec allows for a redundant '+' symbol, we just ignore it.
-        if n != '+' {
-            number.push(n);
-        }
-        for (_, c) in chars.take(c_len) {
-            number.push(c);
-        }
-        if number.to_lowercase().starts_with("0x") {
-            number.remove(0);
-            number.remove(0);
-            (number, 16)
-        } else if number.to_lowercase().starts_with("-0x") {
-            number.remove(1);
-            number.remove(1);
-            (number, 16)
-        } else if let Some(index) = number.to_lowercase().find('r') {
-            let negative = number.starts_with('-');
-            let radix = {
-                if negative {
-                    (number[1..index]).parse::<u32>()
-                } else {
-                    (number[0..index]).parse::<u32>()
-                }
-            };
-            match radix {
-                Ok(r) => {
-                    // from_str_radix panics if radix is not in the range from 2 to 36
-                    if !(2..=36).contains(&r) {
-                        return Err(Error::ParseEdn(format!("Radix of {r} is out of bounds")));
-                    }
-
-                    if negative {
-                        for _ in 0..(index) {
-                            number.remove(1);
-                        }
-                    } else {
-                        for _ in 0..=index {
-                            number.remove(0);
-                        }
-                    }
-                    (number, r)
-                }
-                Err(e) => {
-                    return Err(Error::ParseEdn(format!(
-                        "{e} while trying to parse radix from {number}"
-                    )));
-                }
-            }
-        } else {
-            (number, 10)
-        }
-    };
-
-    match number {
-        n if (n.contains('E') || n.contains('e')) && n.parse::<f64>().is_ok() => {
-            Ok(Edn::Double(n.parse::<f64>()?.into()))
-        }
-        n if u64::from_str_radix(&n, radix).is_ok() => {
-            Ok(Edn::UInt(u64::from_str_radix(&n, radix)?))
-        }
-        n if i64::from_str_radix(&n, radix).is_ok() => {
-            Ok(Edn::Int(i64::from_str_radix(&n, radix)?))
-        }
-        n if n.parse::<f64>().is_ok() => Ok(Edn::Double(n.parse::<f64>()?.into())),
-        n if num_den_from_slice(&n).is_some() => Ok(Edn::Rational(num_den_from_slice(n).unwrap())),
-        n if n.to_uppercase().chars().filter(|c| c == &'E').count() > 1 => {
-            let mut n = n.chars();
-            read_symbol(n.next().unwrap_or(' '), &mut n.enumerate())
-        }
-        _ => Err(Error::ParseEdn(format!(
-            "{number} could not be parsed with radix {radix}"
-        ))),
-    }
-}
-
-fn read_char(chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Result<Edn, Error> {
-    let element = chars
-        .clone()
-        .enumerate()
-        .take_while(|&(_, c)| !c.1.is_whitespace())
-        .map(|(_, c)| c.1)
-        .collect::<String>();
-
-    let mut consume_chars = |n| {
-        // We need to map/collect to consume out of the Enumerate
-        let _ = chars.take(n).map(|c| c.1).collect::<String>();
-    };
-
-    match element {
-        _ if element.starts_with("newline") => {
-            consume_chars(7);
-            Ok(Edn::Char('\n'))
-        }
-        _ if element.starts_with("return") => {
-            consume_chars(6);
-            Ok(Edn::Char('\r'))
-        }
-        _ if element.starts_with("tab") => {
-            consume_chars(3);
-            Ok(Edn::Char('\t'))
-        }
-        _ if element.starts_with("space") => {
-            consume_chars(5);
-            Ok(Edn::Char(' '))
-        }
-        c if !c.is_empty() => {
-            consume_chars(1);
-            Ok(Edn::Char(c.chars().next().unwrap()))
-        }
-        _ => Err(Error::ParseEdn(format!(
-            "{element:?} could not be parsed as a symbol"
-        ))),
-    }
-}
-
-fn read_bool_or_nil(
-    c: char,
-    chars: &mut iter::Enumerate<core::str::Chars<'_>>,
-) -> Result<Edn, Error> {
-    let i = chars
-        .clone()
-        .next()
-        .ok_or_else(|| Error::ParseEdn("Could not identify symbol index".to_string()))?
-        .0;
-    match c {
-        't' if {
-            let val = chars
-                .clone()
-                .take_while(|(_, c)| !c.is_whitespace() && !DELIMITERS.contains(c))
-                .map(|c| c.1)
-                .collect::<String>();
-            val.eq("rue")
-        } =>
-        {
-            let mut string = String::new();
-            let t = chars.take(3).map(|c| c.1).collect::<String>();
-            string.push(c);
-            string.push_str(&t);
-            Ok(Edn::Bool(string.parse::<bool>()?))
-        }
-        'f' if {
-            let val = chars
-                .clone()
-                .take_while(|(_, c)| !c.is_whitespace() && !DELIMITERS.contains(c))
-                .map(|c| c.1)
-                .collect::<String>();
-            val.eq("alse")
-        } =>
-        {
-            let mut string = String::new();
-            let f = chars.take(4).map(|c| c.1).collect::<String>();
-            string.push(c);
-            string.push_str(&f);
-            Ok(Edn::Bool(string.parse::<bool>()?))
-        }
-        'n' if {
-            let val = chars
-                .clone()
-                .take_while(|(_, c)| !c.is_whitespace() && !DELIMITERS.contains(c))
-                .map(|c| c.1)
-                .collect::<String>();
-            val.eq("il")
-        } =>
-        {
-            let mut string = String::new();
-            let n = chars.take(2).map(|c| c.1).collect::<String>();
-            string.push(c);
-            string.push_str(&n);
-            match &string[..] {
-                "nil" => Ok(Edn::Nil),
-                _ => Err(Error::ParseEdn(format!(
-                    "{string} could not be parsed at char count {i}"
-                ))),
-            }
-        }
-        _ => read_symbol(c, chars),
-    }
-}
-
-fn read_vec(chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Result<Edn, Error> {
-    let i = chars
-        .clone()
-        .next()
-        .ok_or_else(|| Error::ParseEdn("Could not identify symbol index".to_string()))?
-        .0;
-    let mut res: Vec<Edn> = vec![];
-    loop {
-        match chars.next() {
-            Some((_, ']')) => return Ok(Edn::Vector(Vector::new(res))),
-            Some(c) => {
-                if let Some(e) = parse_internal(Some(c), chars)? {
-                    res.push(e);
-                }
-            }
-            err => {
-                return Err(Error::ParseEdn(format!(
-                    "{err:?} could not be parsed at char count {i}"
-                )))
-            }
-        }
-    }
-}
-
-fn read_list(chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Result<Edn, Error> {
-    let i = chars
-        .clone()
-        .next()
-        .ok_or_else(|| Error::ParseEdn("Could not identify symbol index".to_string()))?
-        .0;
-    let mut res: Vec<Edn> = vec![];
-    loop {
-        match chars.next() {
-            Some((_, ')')) => return Ok(Edn::List(List::new(res))),
-            Some(c) => {
-                if let Some(e) = parse_internal(Some(c), chars)? {
-                    res.push(e);
-                }
-            }
-            err => {
-                return Err(Error::ParseEdn(format!(
-                    "{err:?} could not be parsed at char count {i}"
-                )))
-            }
-        }
-    }
-}
-
-#[cfg(feature = "sets")]
-fn read_set(chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Result<Edn, Error> {
-    let _discard_brackets = chars.next();
-    let i = chars
-        .clone()
-        .next()
-        .ok_or_else(|| Error::ParseEdn("Could not identify symbol index".to_string()))?
-        .0;
-    let mut res: BTreeSet<Edn> = BTreeSet::new();
-    loop {
-        match chars.next() {
-            Some((_, '}')) => return Ok(Edn::Set(Set::new(res))),
-            Some(c) => {
-                if let Some(e) = parse_internal(Some(c), chars)? {
-                    res.insert(e);
-                }
-            }
-            err => {
-                return Err(Error::ParseEdn(format!(
-                    "{err:?} could not be parsed at char count {i}"
-                )))
-            }
-        }
-    }
-}
-
-#[cfg(not(feature = "sets"))]
-fn read_set(_chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Result<Edn, Error> {
-    Err(Error::ParseEdn(
-        "Could not parse set due to feature not being enabled".to_string(),
-    ))
-}
-
-fn read_map(chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Result<Edn, Error> {
-    let i = chars
-        .clone()
-        .next()
-        .ok_or_else(|| Error::ParseEdn("Could not identify symbol index".to_string()))?
-        .0;
-    let mut res: BTreeMap<String, Edn> = BTreeMap::new();
-    let mut key: Option<Edn> = None;
-    let mut val: Option<Edn> = None;
-    loop {
-        match chars.next() {
-            Some((_, '}')) => return Ok(Edn::Map(Map::new(res))),
-            Some(c) => {
-                if key.is_some() {
-                    val = Some(parse_consuming(Some(c), chars)?);
-                } else {
-                    key = parse_internal(Some(c), chars)?;
-                }
-            }
-            err => {
-                return Err(Error::ParseEdn(format!(
-                    "{err:?} could not be parsed at char count {i}"
-                )))
-            }
-        }
-
-        if key.is_some() && val.is_some() {
-            res.insert(key.unwrap().to_string(), val.unwrap());
-            key = None;
-            val = None;
-        }
-    }
-}
-
-fn read_if_not_container_end(
-    chars: &mut iter::Enumerate<core::str::Chars<'_>>,
-) -> Result<Option<Edn>, Error> {
-    Ok(match chars.clone().next() {
-        Some(c) if c.1 == ']' || c.1 == ')' || c.1 == '}' => None,
-        Some(_) => parse_internal(chars.next(), chars)?,
-        None => None,
-    })
-}
-
-#[cfg(test)]
-mod test {}

--- a/src/deserialize/parse.rs
+++ b/src/deserialize/parse.rs
@@ -1,9 +1,10 @@
+#![allow(clippy::inline_always)]
+
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 #[cfg(feature = "sets")]
 use alloc::collections::BTreeSet;
-use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::primitive::str;
@@ -25,7 +26,7 @@ struct Walker<'w> {
 
 impl Walker<'_> {
     // Slurps until whitespace or delimiter, returning the slice.
-    #[inline]
+    #[inline(always)]
     fn slurp_literal(&mut self) -> &str {
         let token = self.slice[self.ptr..]
             .split(|c: char| c.is_whitespace() || DELIMITERS.contains(&c))
@@ -38,7 +39,7 @@ impl Walker<'_> {
     }
 
     // Slurps a char. Special handling for chars that happen to be delimiters
-    #[inline]
+    #[inline(always)]
     fn slurp_char(&mut self) -> &str {
         let starting_ptr = self.ptr;
 
@@ -57,7 +58,7 @@ impl Walker<'_> {
     }
 
     // Slurps until whitespace or delimiter, returning the slice.
-    #[inline]
+    #[inline(always)]
     fn slurp_tag(&mut self) -> &str {
         let token = self.slice[self.ptr..]
             .split(|c: char| c.is_whitespace() && c != ',')
@@ -73,7 +74,7 @@ impl Walker<'_> {
         token
     }
 
-    #[inline]
+    #[inline(always)]
     fn slurp_str(&mut self) -> Result<Edn, Error> {
         let _ = self.nibble_next(); // Consume the leading '"' char
         let mut s = String::new();
@@ -92,6 +93,7 @@ impl Walker<'_> {
                                 code: Code::InvalidEscape,
                                 column: Some(self.column),
                                 line: Some(self.line),
+                                ptr: Some(self.ptr),
                             })
                         }
                     }
@@ -109,23 +111,22 @@ impl Walker<'_> {
                     code: Code::UnexpectedEOF,
                     column: Some(self.column),
                     line: Some(self.line),
+                    ptr: Some(self.ptr),
                 });
             }
         }
     }
 
     // Nibbles away until the next new line
-    #[inline]
+    #[inline(always)]
     fn nibble_newline(&mut self) {
         let len = self.slice[self.ptr..].split('\n').next().unwrap(); // At least an empty slice will always be on the first split, even on an empty str
-        self.line += 1;
-        self.column = 1;
         self.ptr += len.len();
         self.nibble_whitespace();
     }
 
     // Nibbles away until the start of the next form
-    #[inline]
+    #[inline(always)]
     fn nibble_whitespace(&mut self) {
         while let Some(n) = self.peek_next() {
             if n == ',' || n.is_whitespace() {
@@ -137,7 +138,7 @@ impl Walker<'_> {
     }
 
     // Consumes next
-    #[inline]
+    #[inline(always)]
     fn nibble_next(&mut self) -> Option<char> {
         let char = self.slice[self.ptr..].chars().next();
         if let Some(c) = char {
@@ -153,7 +154,7 @@ impl Walker<'_> {
     }
 
     // Peek into the next char
-    #[inline]
+    #[inline(always)]
     fn peek_next(&mut self) -> Option<char> {
         self.slice[self.ptr..].chars().next()
     }
@@ -167,13 +168,16 @@ pub fn parse(edn: &str) -> Result<Edn, Error> {
         line: 1,
     };
 
-    parse_foobar(&mut walker)
+    parse_internal(&mut walker)
 }
 
-fn parse_foobar(walker: &mut Walker<'_>) -> Result<Edn, Error> {
+#[inline]
+fn parse_internal(walker: &mut Walker<'_>) -> Result<Edn, Error> {
     walker.nibble_whitespace();
     while let Some(next) = walker.peek_next() {
         let column_start = walker.column;
+        let ptr_start = walker.ptr;
+        let line_start = walker.line;
         if let Some(ret) = match next {
             '\\' => match parse_char(walker.slurp_char()) {
                 Ok(edn) => Some(Ok(edn)),
@@ -182,6 +186,7 @@ fn parse_foobar(walker: &mut Walker<'_>) -> Result<Edn, Error> {
                         code,
                         line: Some(walker.line),
                         column: Some(column_start),
+                        ptr: Some(walker.ptr),
                     })
                 }
             },
@@ -201,8 +206,9 @@ fn parse_foobar(walker: &mut Walker<'_>) -> Result<Edn, Error> {
                 Err(code) => {
                     return Err(Error {
                         code,
-                        line: Some(walker.line),
+                        line: Some(line_start),
                         column: Some(column_start),
+                        ptr: Some(ptr_start),
                     })
                 }
             },
@@ -213,6 +219,7 @@ fn parse_foobar(walker: &mut Walker<'_>) -> Result<Edn, Error> {
     Ok(Edn::Empty)
 }
 
+#[inline]
 fn parse_tag_set_discard(walker: &mut Walker<'_>) -> Result<Option<Edn>, Error> {
     let _ = walker.nibble_next(); // Consume the leading '#' char
 
@@ -223,23 +230,26 @@ fn parse_tag_set_discard(walker: &mut Walker<'_>) -> Result<Option<Edn>, Error> 
     }
 }
 
+#[inline]
 fn parse_discard(walker: &mut Walker<'_>) -> Result<Option<Edn>, Error> {
     let _ = walker.nibble_next(); // Consume the leading '_' char
-    Ok(match parse_foobar(walker)? {
+    Ok(match parse_internal(walker)? {
         Edn::Empty => {
             return Err(Error {
                 code: Code::UnexpectedEOF,
                 line: Some(walker.line),
                 column: Some(walker.column),
+                ptr: Some(walker.ptr),
             })
         }
         _ => match walker.peek_next() {
-            Some(_) => Some(parse_foobar(walker)?),
+            Some(_) => Some(parse_internal(walker)?),
             None => None,
         },
     })
 }
 
+#[inline]
 #[cfg(feature = "sets")]
 fn parse_set(walker: &mut Walker<'_>) -> Result<Edn, Error> {
     let _ = walker.nibble_next(); // Consume the leading '{' char
@@ -252,7 +262,7 @@ fn parse_set(walker: &mut Walker<'_>) -> Result<Edn, Error> {
                 return Ok(Edn::Set(Set::new(set)));
             }
             Some(_) => {
-                let next = parse_foobar(walker)?;
+                let next = parse_internal(walker)?;
                 if next != Edn::Empty {
                     set.insert(next);
                 }
@@ -262,29 +272,34 @@ fn parse_set(walker: &mut Walker<'_>) -> Result<Edn, Error> {
                     code: Code::UnexpectedEOF,
                     line: Some(walker.line),
                     column: Some(walker.column),
+                    ptr: Some(walker.ptr),
                 })
             }
         }
     }
 }
 
+#[inline]
 #[cfg(not(feature = "sets"))]
 const fn parse_set(walker: &Walker<'_>) -> Result<Edn, Error> {
     Err(Error {
         code: Code::NoFeatureSets,
         line: Some(walker.line),
         column: Some(walker.column),
+        ptr: Some(walker.ptr),
     })
 }
 
+#[inline]
 fn parse_tag(walker: &mut Walker<'_>) -> Result<Edn, Error> {
     let tag = walker.slurp_tag();
     Ok(Edn::Tagged(
         tag.to_string(),
-        Box::new(parse_foobar(walker)?),
+        Box::new(parse_internal(walker)?),
     ))
 }
 
+#[inline]
 fn parse_map(walker: &mut Walker<'_>) -> Result<Edn, Error> {
     let _ = walker.nibble_next(); // Consume the leading '{' char
     let mut map: BTreeMap<String, Edn> = BTreeMap::new();
@@ -300,14 +315,23 @@ fn parse_map(walker: &mut Walker<'_>) -> Result<Edn, Error> {
                         code: Code::UnmatchedDelimiter(n),
                         line: Some(walker.line),
                         column: Some(walker.column),
+                        ptr: Some(walker.ptr),
                     });
                 }
 
-                let key = parse_foobar(walker)?;
-                let val = parse_foobar(walker)?;
+                let key = parse_internal(walker)?;
+                let val = parse_internal(walker)?;
 
                 if key != Edn::Empty && val != Edn::Empty {
-                    map.insert(key.to_string(), val);
+                    // Existing keys are considered an error
+                    if map.insert(key.to_string(), val).is_some() {
+                        return Err(Error {
+                            code: Code::HashMapDuplicateKey,
+                            line: Some(walker.line),
+                            column: Some(walker.column),
+                            ptr: Some(walker.ptr),
+                        });
+                    }
                 }
             }
             _ => {
@@ -315,12 +339,14 @@ fn parse_map(walker: &mut Walker<'_>) -> Result<Edn, Error> {
                     code: Code::UnexpectedEOF,
                     line: Some(walker.line),
                     column: Some(walker.column),
+                    ptr: Some(walker.ptr),
                 })
             }
         }
     }
 }
 
+#[inline]
 fn parse_vector(walker: &mut Walker<'_>) -> Result<Edn, Error> {
     let _ = walker.nibble_next(); // Consume the leading '[' char
     let mut vec = Vec::new();
@@ -332,7 +358,7 @@ fn parse_vector(walker: &mut Walker<'_>) -> Result<Edn, Error> {
                 return Ok(Edn::Vector(Vector::new(vec)));
             }
             Some(_) => {
-                let next = parse_foobar(walker)?;
+                let next = parse_internal(walker)?;
                 if next != Edn::Empty {
                     vec.push(next);
                 }
@@ -342,12 +368,14 @@ fn parse_vector(walker: &mut Walker<'_>) -> Result<Edn, Error> {
                     code: Code::UnexpectedEOF,
                     line: Some(walker.line),
                     column: Some(walker.column),
+                    ptr: Some(walker.ptr),
                 })
             }
         }
     }
 }
 
+#[inline]
 fn parse_list(walker: &mut Walker<'_>) -> Result<Edn, Error> {
     let _ = walker.nibble_next(); // Consume the leading '[' char
     let mut vec = Vec::new();
@@ -359,7 +387,7 @@ fn parse_list(walker: &mut Walker<'_>) -> Result<Edn, Error> {
                 return Ok(Edn::List(List::new(vec)));
             }
             Some(_) => {
-                let next = parse_foobar(walker)?;
+                let next = parse_internal(walker)?;
                 if next != Edn::Empty {
                     vec.push(next);
                 }
@@ -369,12 +397,14 @@ fn parse_list(walker: &mut Walker<'_>) -> Result<Edn, Error> {
                     code: Code::UnexpectedEOF,
                     line: Some(walker.line),
                     column: Some(walker.column),
+                    ptr: Some(walker.ptr),
                 })
             }
         }
     }
 }
 
+#[inline]
 fn edn_literal(literal: &str) -> Result<Edn, Code> {
     fn numeric(s: &str) -> bool {
         let mut s = s.chars();
@@ -414,6 +444,7 @@ fn edn_literal(literal: &str) -> Result<Edn, Code> {
     })
 }
 
+#[inline]
 fn parse_char(lit: &str) -> Result<Edn, Code> {
     let lit = &lit[1..]; // ignore the leading '\\'
     match lit {
@@ -426,6 +457,7 @@ fn parse_char(lit: &str) -> Result<Edn, Code> {
     }
 }
 
+#[inline]
 fn parse_number(lit: &str) -> Result<Edn, Code> {
     let mut chars = lit.chars();
     let (number, radix) = {
@@ -497,12 +529,11 @@ fn parse_number(lit: &str) -> Result<Edn, Code> {
         }
         n if n.parse::<f64>().is_ok() => Ok(Edn::Double(n.parse::<f64>()?.into())),
         n if num_den_from_slice(&n).is_some() => Ok(Edn::Rational(num_den_from_slice(n).unwrap())),
-        _ => Err(Code::Message(
-            format!("{number} could not be parsed with radix {radix}").into_boxed_str(),
-        )),
+        _ => Err(Code::InvalidNumber),
     }
 }
 
+#[inline]
 fn num_den_from_slice(slice: impl AsRef<str>) -> Option<(i64, u64)> {
     let slice = slice.as_ref();
     let index = slice.find('/');

--- a/src/edn/error.rs
+++ b/src/edn/error.rs
@@ -1,0 +1,115 @@
+use alloc::boxed::Box;
+use core::fmt::{self, Debug, Display};
+use core::{convert, num, str};
+
+pub struct Error {
+    pub(crate) code: Code,
+    pub(crate) line: Option<usize>,
+    pub(crate) column: Option<usize>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Code {
+    /// Catchall/placeholder error messages
+    Message(Box<str>),
+
+    /// Parse errors
+    InvalidChar,
+    InvalidEscape,
+    InvalidKeyword,
+    InvalidRadix(Option<u8>),
+    ParseNumber(ParseNumber),
+    UnexpectedEOF,
+    UnmatchedDelimiter(char),
+
+    // Feature errors
+    NoFeatureSets,
+
+    // Deserialize errors
+    Convert(&'static str),
+
+    // Navigation errors
+    Iter,
+
+    /// For type conversions
+    TryFromInt(num::TryFromIntError),
+    #[doc(hidden)]
+    Infallable(), // Makes the compiler happy for converting u64 to u64 and i64 to i64
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ParseNumber {
+    ParseIntError(num::ParseIntError),
+    ParseFloatError(num::ParseFloatError),
+}
+
+impl Error {
+    pub(crate) const fn deserialize(conv_type: &'static str) -> Self {
+        Self {
+            code: Code::Convert(conv_type),
+            line: None,
+            column: None,
+        }
+    }
+    pub(crate) const fn iter() -> Self {
+        Self {
+            code: Code::Iter,
+            line: None,
+            column: None,
+        }
+    }
+}
+
+impl Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "EdnError {{ code: {:?}, line: {:?}, column: {:?} }}",
+            self.code, self.line, self.column
+        )
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.code {
+            Code::Message(m) => write!(f, "{}", m.as_ref()),
+            Code::TryFromInt(e) => write!(f, "{e}"),
+            _ => todo!(),
+        }
+    }
+}
+
+impl From<num::ParseIntError> for Code {
+    fn from(e: num::ParseIntError) -> Self {
+        Self::ParseNumber(ParseNumber::ParseIntError(e))
+    }
+}
+
+impl From<num::ParseFloatError> for Code {
+    fn from(e: num::ParseFloatError) -> Self {
+        Self::ParseNumber(ParseNumber::ParseFloatError(e))
+    }
+}
+
+impl From<convert::Infallible> for Error {
+    fn from(_: convert::Infallible) -> Self {
+        Self {
+            code: Code::Infallable(),
+            line: None,
+            column: None,
+        }
+    }
+}
+
+impl From<num::TryFromIntError> for Error {
+    fn from(e: num::TryFromIntError) -> Self {
+        Self {
+            code: Code::TryFromInt(e),
+            line: None,
+            column: None,
+        }
+    }
+}

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -7,7 +7,7 @@ use alloc::vec::Vec;
 use alloc::{fmt, format};
 #[cfg(feature = "sets")]
 use core::cmp::{Ord, PartialOrd};
-use core::convert::{Infallible, TryFrom};
+use core::convert::TryFrom;
 use core::num;
 
 use crate::deserialize::parse::{self};
@@ -16,6 +16,7 @@ use utils::index::Index;
 #[cfg(feature = "sets")]
 use ordered_float::OrderedFloat;
 
+pub mod error;
 #[doc(hidden)]
 pub mod utils;
 
@@ -692,7 +693,7 @@ impl Edn {
 }
 
 impl core::str::FromStr for Edn {
-    type Err = Error;
+    type Err = error::Error;
 
     /// Parses a `&str` that contains an Edn into `Result<Edn, EdnError>`
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -710,63 +711,6 @@ where
 #[allow(clippy::cast_precision_loss)]
 pub(crate) fn rational_to_double((n, d): (i64, u64)) -> f64 {
     (n as f64) / (d as f64)
-}
-
-#[derive(Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum Error {
-    ParseEdn(String),
-    Deserialize(String),
-    Iter(String),
-    TryFromInt(num::TryFromIntError),
-    #[doc(hidden)]
-    Infallable(), // Makes the compiler happy for converting u64 to u64 and i64 to i64
-}
-
-impl From<String> for Error {
-    fn from(s: String) -> Self {
-        Self::ParseEdn(s)
-    }
-}
-
-impl From<num::ParseIntError> for Error {
-    fn from(s: num::ParseIntError) -> Self {
-        Self::ParseEdn(s.to_string())
-    }
-}
-
-impl From<num::ParseFloatError> for Error {
-    fn from(s: num::ParseFloatError) -> Self {
-        Self::ParseEdn(s.to_string())
-    }
-}
-
-impl From<core::str::ParseBoolError> for Error {
-    fn from(s: core::str::ParseBoolError) -> Self {
-        Self::ParseEdn(s.to_string())
-    }
-}
-
-impl From<num::TryFromIntError> for Error {
-    fn from(e: num::TryFromIntError) -> Self {
-        Self::TryFromInt(e)
-    }
-}
-
-impl From<Infallible> for Error {
-    fn from(_: Infallible) -> Self {
-        Self::Infallable()
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::ParseEdn(s) | Self::Deserialize(s) | Self::Iter(s) => write!(f, "{}", &s),
-            Self::TryFromInt(e) => write!(f, "{e}"),
-            Self::Infallable() => panic!("Infallable conversion"),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub fn json_to_edn<'a>(json: impl AsRef<str>) -> Cow<'a, str> {
 }
 
 pub use deserialize::{from_edn, from_str, Deserialize};
-pub use edn::Error as EdnError;
+pub use edn::error::Error as EdnError;
 #[cfg(feature = "sets")]
 pub use edn::Set;
 pub use edn::{Edn, List, Map, Vector};

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -18,6 +18,11 @@ mod test {
     #[test]
     fn parse_empty() {
         assert_eq!(Edn::from_str("").unwrap(), Edn::Empty);
+        assert_eq!(
+            Edn::from_str("[]").unwrap(),
+            Edn::Vector(Vector::new(vec![]))
+        );
+        assert_eq!(Edn::from_str("()").unwrap(), Edn::List(List::new(vec![])));
     }
 
     #[test]
@@ -928,5 +933,12 @@ mod test {
                 Edn::Char('_'),
             ]))
         );
+    }
+
+    #[test]
+    fn invalid_edn() {
+        assert!(Edn::from_str("{ :foo 42 :foo 43 }").is_err());
+        assert!(Edn::from_str("{ :[0x42] 42 }").is_err());
+        assert!(Edn::from_str("\\cats").is_err());
     }
 }

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -5,7 +5,6 @@ mod test {
     use alloc::collections::BTreeMap;
     use core::str::FromStr;
 
-    use edn::Error;
     use edn_rs::{edn, from_edn, from_str, hmap, map, Edn, List, Map, Vector};
 
     #[test]
@@ -33,12 +32,7 @@ mod test {
     #[cfg(not(feature = "sets"))]
     // Special case of running into a set without the feature enabled
     fn parse_set_without_set_feature() {
-        assert_eq!(
-            Edn::from_str("#{true, \\c, 3,four, }"),
-            Err(Error::ParseEdn(
-                "Could not parse set due to feature not being enabled".to_string()
-            ))
-        )
+        assert!(Edn::from_str("#{true, \\c, 3,four, }").is_err())
     }
 
     #[test]
@@ -108,18 +102,14 @@ mod test {
 
     #[test]
     fn parse_str_with_invalid_escape() {
-        assert_eq!(
-            Edn::from_str(r#""hello\n \r \t \"world\" with escaped \\ \g characters""#),
-            Err(Error::ParseEdn("Invalid escape sequence \\g".to_string()))
+        assert!(
+            Edn::from_str(r#""hello\n \r \t \"world\" with escaped \\ \g characters""#).is_err()
         );
     }
 
     #[test]
     fn parse_unterminated_string() {
-        assert_eq!(
-            Edn::from_str(r#""hello\n \r \t \"world\" with escaped \\ characters"#),
-            Err(Error::ParseEdn("Unterminated string".to_string()))
-        );
+        assert!(Edn::from_str(r#""hello\n \r \t \"world\" with escaped \\ characters"#).is_err());
     }
 
     #[test]
@@ -159,15 +149,15 @@ mod test {
         let edn = "[1 \"2\" 3.3 :b true \\c]";
 
         assert_eq!(
-            Edn::from_str(edn),
-            Ok(Edn::Vector(Vector::new(vec![
+            Edn::from_str(edn).unwrap(),
+            Edn::Vector(Vector::new(vec![
                 Edn::UInt(1),
                 Edn::Str("2".to_string()),
                 Edn::Double(3.3.into()),
                 Edn::Key(":b".to_string()),
                 Edn::Bool(true),
                 Edn::Char('c')
-            ])))
+            ]))
         );
     }
 
@@ -294,14 +284,14 @@ mod test {
         let edn = "(1 \"2\" 3.3 :b [true \\c])";
 
         assert_eq!(
-            Edn::from_str(edn),
-            Ok(Edn::List(List::new(vec![
+            Edn::from_str(edn).unwrap(),
+            Edn::List(List::new(vec![
                 Edn::UInt(1),
                 Edn::Str("2".to_string()),
                 Edn::Double(3.3.into()),
                 Edn::Key(":b".to_string()),
                 Edn::Vector(Vector::new(vec![Edn::Bool(true), Edn::Char('c')]))
-            ])))
+            ]))
         );
     }
 
@@ -347,11 +337,11 @@ mod test {
         let edn = "{:a \"2\" :b true :c nil}";
 
         assert_eq!(
-            Edn::from_str(edn),
-            Ok(Edn::Map(Map::new(
+            Edn::from_str(edn).unwrap(),
+            Edn::Map(Map::new(
                 map! {":a".to_string() => Edn::Str("2".to_string()),
                 ":b".to_string() => Edn::Bool(true), ":c".to_string() => Edn::Nil}
-            )))
+            ))
         );
     }
 
@@ -425,12 +415,7 @@ mod test {
 
     #[test]
     fn parse_discard_invalid() {
-        assert_eq!(
-            Edn::from_str("#_{ 234"),
-            Err(Error::ParseEdn(
-                "None could not be parsed at char count 3".to_string()
-            ))
-        );
+        assert!(Edn::from_str("#_{ 234").is_err());
     }
 
     #[test]
@@ -463,12 +448,7 @@ mod test {
 
     #[test]
     fn parse_discard_no_follow_element() {
-        assert_eq!(
-            Edn::from_str("#_ ,, "),
-            Err(Error::ParseEdn(
-                "Discard sequence must have a following element at char count 2".to_string()
-            ))
-        );
+        assert!(Edn::from_str("#_ ,, ").is_err());
     }
 
     #[test]
@@ -481,12 +461,7 @@ mod test {
 
     #[test]
     fn parse_discard_end_of_seq_no_follow() {
-        assert_eq!(
-            Edn::from_str("[:foo #_ ]"),
-            Err(Error::ParseEdn(
-                "Discard sequence must have a following element at char count 8".to_string()
-            ))
-        );
+        assert!(Edn::from_str("[:foo #_ ]").is_err());
     }
 
     #[test]
@@ -853,32 +828,10 @@ mod test {
 
     #[test]
     fn parse_invalid_ints() {
-        assert_eq!(
-            Edn::from_str("42invalid123"),
-            Err(Error::ParseEdn(
-                "42invalid123 could not be parsed with radix 10".to_string()
-            ))
-        );
-
-        assert_eq!(
-            Edn::from_str("0xxyz123"),
-            Err(Error::ParseEdn(
-                "xyz123 could not be parsed with radix 16".to_string()
-            ))
-        );
-
-        assert_eq!(
-            Edn::from_str("42rabcxzy"),
-            Err(Error::ParseEdn("Radix of 42 is out of bounds".to_string()))
-        );
-
-        assert_eq!(
-            Edn::from_str("42crazyrabcxzy"),
-            Err(Error::ParseEdn(
-                "invalid digit found in string while trying to parse radix from 42crazyrabcxzy"
-                    .to_string()
-            ))
-        );
+        assert!(Edn::from_str("42invalid123").is_err());
+        assert!(Edn::from_str("0xxyz123").is_err());
+        assert!(Edn::from_str("42rabcxzy").is_err());
+        assert!(Edn::from_str("42crazyrabcxzy").is_err());
     }
 
     #[test]
@@ -942,12 +895,7 @@ mod test {
     fn weird_input() {
         let edn = "{:a]";
 
-        assert_eq!(
-            Edn::from_str(edn),
-            Err(Error::ParseEdn(
-                "Could not identify symbol index".to_string()
-            ))
-        );
+        assert!(Edn::from_str(edn).is_err());
     }
 
     #[test]

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -29,13 +29,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(feature = "sets"))]
-    // Special case of running into a set without the feature enabled
-    fn parse_set_without_set_feature() {
-        assert!(Edn::from_str("#{true, \\c, 3,four, }").is_err())
-    }
-
-    #[test]
     fn parse_commas_are_whitespace() {
         assert_eq!(Edn::from_str(",,,,, \r\n,,,").unwrap(), Edn::Empty);
     }
@@ -779,10 +772,7 @@ mod test {
 
     #[test]
     fn parse_numberic_symbol_with_doube_e() {
-        assert_eq!(
-            Edn::from_str("5011227E71367421E12").unwrap(),
-            Edn::Symbol("5011227E71367421E12".to_string())
-        );
+        assert!(Edn::from_str("5011227E71367421E12").is_err());
     }
 
     #[test]

--- a/tests/deserialize_sets.rs
+++ b/tests/deserialize_sets.rs
@@ -6,8 +6,8 @@ mod test {
     use alloc::collections::BTreeSet;
     use core::str::FromStr;
 
-    use edn::{Error, List, Vector};
-    use edn_rs::{edn, from_edn, from_str, hset, map, set, Edn, Map, Set};
+    use edn::{List, Vector};
+    use edn_rs::{edn, from_edn, from_str, hset, map, set, Edn, EdnError, Map, Set};
 
     #[test]
     fn parse_set_with_commas() {
@@ -172,7 +172,7 @@ mod test {
     #[test]
     fn deser_btreeset_with_error() {
         let edn = "#{\"a\", 5, \"b\"}";
-        let err: Result<BTreeSet<u64>, Error> = from_str(edn);
+        let err: Result<BTreeSet<u64>, EdnError> = from_str(edn);
 
         assert!(err.is_err());
     }

--- a/tests/deserialize_sets.rs
+++ b/tests/deserialize_sets.rs
@@ -59,15 +59,15 @@ mod test {
         let edn = "(1 -10 \"2\" 3.3 :b #{true \\c})";
 
         assert_eq!(
-            Edn::from_str(edn),
-            Ok(Edn::List(List::new(vec![
+            Edn::from_str(edn).unwrap(),
+            Edn::List(List::new(vec![
                 Edn::UInt(1),
                 Edn::Int(-10),
                 Edn::Str("2".to_string()),
                 Edn::Double(3.3.into()),
                 Edn::Key(":b".to_string()),
                 Edn::Set(Set::new(set![Edn::Bool(true), Edn::Char('c')]))
-            ])))
+            ]))
         );
     }
 
@@ -114,15 +114,15 @@ mod test {
         let edn = "{:a \"2\" :b [true false] :c #{:A {:a :b} nil}}";
 
         assert_eq!(
-            Edn::from_str(edn),
-            Ok(Edn::Map(Map::new(map! {
+            Edn::from_str(edn).unwrap(),
+            Edn::Map(Map::new(map! {
             ":a".to_string() =>Edn::Str("2".to_string()),
             ":b".to_string() => Edn::Vector(Vector::new(vec![Edn::Bool(true), Edn::Bool(false)])),
             ":c".to_string() => Edn::Set(Set::new(
                 set!{
                     Edn::Map(Map::new(map!{":a".to_string() => Edn::Key(":b".to_string())})),
                     Edn::Key(":A".to_string()),
-                    Edn::Nil}))})))
+                    Edn::Nil}))}))
         );
     }
 
@@ -148,14 +148,10 @@ mod test {
 
     #[test]
     fn parse_discard_space_invalid() {
-        assert_eq!(
-            Edn::from_str(
-                "#_ ,, #{hello, this will be discarded} #_{so will this} #{this is invalid"
-            ),
-            Err(Error::ParseEdn(
-                "None could not be parsed at char count 58".to_string()
-            ))
-        );
+        assert!(Edn::from_str(
+            "#_ ,, #{hello, this will be discarded} #_{so will this} #{this is invalid"
+        )
+        .is_err());
     }
 
     #[test]
@@ -177,13 +173,8 @@ mod test {
     fn deser_btreeset_with_error() {
         let edn = "#{\"a\", 5, \"b\"}";
         let err: Result<BTreeSet<u64>, Error> = from_str(edn);
-        assert_eq!(
-            err,
-            Err(Error::Deserialize(
-                "Cannot safely deserialize Set(Set({Str(\"a\"), Str(\"b\"), UInt(5)})) to BTreeSet"
-                    .to_string()
-            ))
-        );
+
+        assert!(err.is_err());
     }
 
     #[test]

--- a/tests/emit_json.rs
+++ b/tests/emit_json.rs
@@ -87,14 +87,13 @@ mod tests {
     #[test]
     fn regression_str_to_uint_test() {
         use edn_derive::Deserialize;
-        use edn_rs::EdnError;
         #[derive(Deserialize, Debug, PartialEq)]
         struct A {
             amount: u64,
         }
 
-        let a: Result<A, EdnError> = edn_rs::from_str("{ :amount \"123\" }");
-        assert_eq!(a, Ok(A { amount: 123 }));
+        let a: A = edn_rs::from_str("{ :amount \"123\" }").unwrap();
+        assert_eq!(a, A { amount: 123 });
     }
 
     #[test]

--- a/tests/error_messages.rs
+++ b/tests/error_messages.rs
@@ -13,15 +13,15 @@ mod test {
     fn invalid_keyword() {
         assert_eq!(
             debug_msg(":"),
-            "EdnError { code: InvalidKeyword, line: Some(1), column: Some(1) }"
+            "EdnError { code: InvalidKeyword, line: Some(1), column: Some(1), index: Some(0) }"
         );
         assert_eq!(
             debug_msg("  :"),
-            "EdnError { code: InvalidKeyword, line: Some(1), column: Some(3) }"
+            "EdnError { code: InvalidKeyword, line: Some(1), column: Some(3), index: Some(2) }"
         );
         assert_eq!(
             debug_msg("\n\n   :"),
-            "EdnError { code: InvalidKeyword, line: Some(3), column: Some(4) }"
+            "EdnError { code: InvalidKeyword, line: Some(3), column: Some(4), index: Some(5) }"
         );
     }
 
@@ -29,7 +29,7 @@ mod test {
     fn unexpected_eof() {
         assert_eq!(
             debug_msg(r#""hello, world!"#),
-            "EdnError { code: UnexpectedEOF, line: Some(1), column: Some(15) }"
+            "EdnError { code: UnexpectedEOF, line: Some(1), column: Some(15), index: Some(14) }"
         );
         assert_eq!(
             debug_msg(
@@ -38,7 +38,31 @@ multiple
 lines
 world!"#
             ),
-            "EdnError { code: UnexpectedEOF, line: Some(4), column: Some(7) }"
+            "EdnError { code: UnexpectedEOF, line: Some(4), column: Some(7), index: Some(29) }"
+        );
+    }
+
+    #[test]
+    fn invalid_num() {
+        assert_eq!(
+            debug_msg(" ,,,, , , ,,,, ,\n ,,,,       0xfoobarlol"),
+            "EdnError { code: InvalidNumber, line: Some(2), column: Some(13), index: Some(29) }"
+        );
+        assert_eq!(
+            debug_msg("[ ; comment \n-0xfoobarlol 0xsilycat]"),
+            "EdnError { code: InvalidNumber, line: Some(2), column: Some(1), index: Some(13) }"
+        );
+        assert_eq!(
+            debug_msg("[ ;;;,,,,\n , , ,,,, ,\n ,,,,   16  -0xfoobarlol 0xsilycat]"),
+            "EdnError { code: InvalidNumber, line: Some(3), column: Some(13), index: Some(34) }"
+        );
+    }
+
+    #[test]
+    fn utf8() {
+        assert_eq!(
+            debug_msg("(猫 ; cat\nおやつ;treats\n      "),
+            "EdnError { code: UnexpectedEOF, line: Some(3), column: Some(7), index: Some(34) }"
         );
     }
 
@@ -48,7 +72,12 @@ world!"#
         // Special case of running into a set without the feature enabled
         assert_eq!(
             debug_msg("#{true, \\c, 3,four, }",),
-            "EdnError { code: NoFeatureSets, line: Some(1), column: Some(2) }"
+            "EdnError { code: NoFeatureSets, line: Some(1), column: Some(2), index: Some(1) }"
+        );
+
+        assert_eq!(
+            debug_msg("[1 \n2 ;3 \n4 #{true, \\c, 3,four, }]",),
+            "EdnError { code: NoFeatureSets, line: Some(3), column: Some(4), index: Some(13) }"
         );
     }
 }

--- a/tests/error_messages.rs
+++ b/tests/error_messages.rs
@@ -1,0 +1,54 @@
+#[cfg(test)]
+mod test {
+    use core::str::FromStr;
+
+    use edn_rs::Edn;
+
+    fn debug_msg(s: &str) -> String {
+        let err = Edn::from_str(s).err().unwrap();
+        format!("{err:?}")
+    }
+
+    #[test]
+    fn invalid_keyword() {
+        assert_eq!(
+            debug_msg(":"),
+            "EdnError { code: InvalidKeyword, line: Some(1), column: Some(1) }"
+        );
+        assert_eq!(
+            debug_msg("  :"),
+            "EdnError { code: InvalidKeyword, line: Some(1), column: Some(3) }"
+        );
+        assert_eq!(
+            debug_msg("\n\n   :"),
+            "EdnError { code: InvalidKeyword, line: Some(3), column: Some(4) }"
+        );
+    }
+
+    #[test]
+    fn unexpected_eof() {
+        assert_eq!(
+            debug_msg(r#""hello, world!"#),
+            "EdnError { code: UnexpectedEOF, line: Some(1), column: Some(15) }"
+        );
+        assert_eq!(
+            debug_msg(
+                r#""hello,
+multiple
+lines
+world!"#
+            ),
+            "EdnError { code: UnexpectedEOF, line: Some(4), column: Some(7) }"
+        );
+    }
+
+    #[test]
+    #[cfg(not(feature = "sets"))]
+    fn disabled_features() {
+        // Special case of running into a set without the feature enabled
+        assert_eq!(
+            debug_msg("#{true, \\c, 3,four, }",),
+            "EdnError { code: NoFeatureSets, line: Some(1), column: Some(2) }"
+        );
+    }
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -8,6 +8,7 @@ pub mod deserialize;
 pub mod deserialize_sets;
 pub mod emit;
 pub mod emit_json;
+pub mod error_messages;
 pub mod parse;
 pub mod parse_sets;
 pub mod ser;


### PR DESCRIPTION
# Performance
Note this is using the benchmark in `main`. The performance increase should be much better on larger strings, as there is now no `clone()` in parse. The only allocations are for constructing the EDN struct and for parsing numbers. Note that the walker is now all pointer based. Peeking was a big reason previously for the clones, you can see the new performance characteristics (utf-8 complexity but no allocations) https://godbolt.org/z/zK9dEzrYn
## Before
```
     Running benches/parse.rs (target/release/deps/parse-5de3e714a9fe6fe3)
parse                   time:   [23.316 µs 24.270 µs 25.380 µs]
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
```
```
     Running benches/tagged_parse.rs (target/release/deps/tagged_parse-041b63e457dffa70)
tagged_parse            time:   [4.4875 µs 4.5609 µs 4.6395 µs]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
  ```

## After
```
     Running benches/parse.rs (target/release/deps/parse-5de3e714a9fe6fe3)
parse                   time:   [4.6219 µs 4.6649 µs 4.7142 µs]
                        change: [-81.813% -80.967% -80.093%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  8 (8.00%) high severe
  ```
  ```
       Running benches/tagged_parse.rs (target/release/deps/tagged_parse-041b63e457dffa70)
tagged_parse            time:   [1.6429 µs 1.6504 µs 1.6588 µs]
                        change: [-65.166% -64.416% -63.697%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
  ```
# Debug
given
```rust
let edn = "#_ ,, #{hello, this will be discarded} #_{so will this} #{this is invalid";
let e = Edn::from_str(edn);
println!("{e:?}");
```
## Before
`Err(ParseEdn("None could not be parsed at char count 58"))`
## After
`Err(EdnError { code: UnexpectedEOF, line: Some(1), column: Some(74), index: Some(73) })`
Exmples/tests can be found at https://github.com/Grinkers/edn-rs/blob/4365f555f997df08ecffce32a65c18b0dd76870d/tests/error_messages.rs
# Errors
In this rework, the following strings were also previously being parsed as valid EDN. Fuzzing invalid EDN is still a TODO (separate issue/PR).
```clojure
":"
"5011227E71367421E12" ; https://github.com/edn-format/edn#symbols
"{ :[0x42] 42 }"
"\\cats"
"{ :foo 42 :foo 43 }"
```